### PR TITLE
enable WASM StorageAdapter to also work in mocked `nodejs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,21 +1195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "gloo-storage"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc8031e8c92758af912f9bc08fbbadd3c6f3cfcbf6b64cdf3d6a81f0139277a"
-dependencies = [
- "gloo-utils",
- "js-sys",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,19 +1204,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1554,7 +1526,6 @@ dependencies = [
  "fern-logger",
  "futures",
  "getset",
- "gloo-storage",
  "gloo-timers",
  "hashbrown",
  "heck",
@@ -1588,6 +1559,7 @@ dependencies = [
  "tokio",
  "url",
  "wasm-bindgen-futures",
+ "web-sys",
  "zeroize",
 ]
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -113,7 +113,7 @@ tokio = { version = "1.36.0", default-features = false, features = [
 ], optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-gloo-storage = { version = "0.3.0", default-features = false, optional = true }
+web-sys = { version = "0.3", features = ["Storage"], optional = true }
 gloo-timers = { version = "0.3.0", default-features = false, features = [
     "futures",
 ] }
@@ -185,6 +185,7 @@ storage = [
     "dep:anymap3",
     "dep:once_cell",
     "dep:heck",
+	"dep:web-sys",
 ]
 stronghold = [
     "iota_stronghold",
@@ -217,6 +218,8 @@ client = [
     "iota-crypto/random",
 ]
 wallet = ["client"]
+
+test = []
 
 # Ed25519 Examples
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -219,8 +219,6 @@ client = [
 ]
 wallet = ["client"]
 
-test = []
-
 # Ed25519 Examples
 
 [[example]]

--- a/sdk/src/wallet/core/builder.rs
+++ b/sdk/src/wallet/core/builder.rs
@@ -133,15 +133,20 @@ where
         }
 
         #[cfg(feature = "storage")]
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "rocksdb")] {
-                let storage = crate::wallet::storage::adapter::rocksdb::RocksdbStorageAdapter::new(storage_options.path.clone())?;
-            } else if #[cfg(feature = "jammdb")] {
-                let storage = crate::wallet::storage::adapter::jammdb::JammdbStorageAdapter::new(storage_options.path.clone())?;
-            } else {
-                let storage = crate::wallet::storage::adapter::memory::Memory::default();
+        let storage = {
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "rocksdb")] {
+                     crate::wallet::storage::adapter::rocksdb::RocksdbStorageAdapter::new(storage_options.path.clone())?
+                } else if #[cfg(feature = "jammdb")] {
+                    crate::wallet::storage::adapter::jammdb::JammdbStorageAdapter::new(storage_options.path.clone())?
+                } else if #[cfg(target_family = "wasm")] {
+                    // if we are on wasm, try to use the browser local storage
+                    crate::wallet::storage::adapter::wasm::WasmAdapter::new()?
+                } else {
+                    crate::wallet::storage::adapter::memory::Memory::default()
+                }
             }
-        }
+        };
 
         #[cfg(feature = "storage")]
         let mut storage_manager = StorageManager::new(storage, storage_options.encryption_key.clone()).await?;

--- a/sdk/src/wallet/storage/adapter/mod.rs
+++ b/sdk/src/wallet/storage/adapter/mod.rs
@@ -12,6 +12,9 @@ pub mod rocksdb;
 #[cfg_attr(docsrs, doc(cfg(feature = "jammdb")))]
 pub mod jammdb;
 
+#[cfg(target_family = "wasm")]
+pub mod wasm;
+
 use async_trait::async_trait;
 
 use crate::client::storage::StorageAdapter;

--- a/sdk/src/wallet/storage/adapter/wasm.rs
+++ b/sdk/src/wallet/storage/adapter/wasm.rs
@@ -17,18 +17,17 @@ pub struct WasmAdapter {
     _ignored: (),
 }
 
-const PROBE_KEY: &str = "iota-sdk-availability-test";
-const PROBE_VALUE: &str = "local storage is available!";
-
 impl WasmAdapter {
+    /// Tries to instantiate a new [`WasmAdapter`] by checking if the local storage API is
+    /// available with a simple write-read cycle.
     pub fn new() -> crate::wallet::Result<Self> {
-        // just do a quick check to see if the API is available!
-
-        // do a write-read cycle, and if any of them fail, wrap the error and return it
-
         let storage = Self::storage()?;
 
+        // do a write-read cycle, and if any of them fail, wrap the error and return it
         let out = || -> Result<bool, JsValue> {
+            const PROBE_KEY: &str = "iota-sdk-availability-test";
+            const PROBE_VALUE: &str = "probe_value";
+
             storage.set_item(PROBE_KEY, PROBE_VALUE)?;
             let read = storage.get_item(PROBE_KEY)?;
             let _ = storage.remove_item(PROBE_KEY);

--- a/sdk/src/wallet/storage/adapter/wasm.rs
+++ b/sdk/src/wallet/storage/adapter/wasm.rs
@@ -1,7 +1,9 @@
 // Copyright 2023 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use gloo_storage::LocalStorage;
+use web_sys::{js_sys, wasm_bindgen::JsValue};
+
+use crate::wallet::Error;
 
 use super::StorageAdapter;
 
@@ -10,35 +12,81 @@ pub const STORAGE_ID: &str = "Wasm";
 
 /// Wasm storage adapter using the browser local storage
 #[derive(Debug)]
-pub struct WasmAdapter(LocalStorage);
+pub struct WasmAdapter {
+    /// field used just to make it impossible to create a [`WasmAdapter`] without using the `new` function.
+    _ignored: (),
+}
+
+const PROBE_KEY: &str = "iota-sdk-availability-test";
+const PROBE_VALUE: &str = "local storage is available!";
 
 impl WasmAdapter {
-    /// Initialises the storage adapter.
     pub fn new() -> crate::wallet::Result<Self> {
-        Ok(Self(LocalStorage::new()))
+        // just do a quick check to see if the API is available!
+
+        // do a write-read cycle, and if any of them fail, wrap the error and return it
+
+        let storage = Self::storage()?;
+
+        let out = || -> Result<bool, JsValue> {
+            storage.set_item(PROBE_KEY, PROBE_VALUE)?;
+            let read = storage.get_item(PROBE_KEY)?;
+            Ok(read.is_some_and(|v| v == PROBE_VALUE))
+        }();
+
+        let matched = out.map_err(|e| Error::Storage(format!("localStorage probe check failed with error: {e:?}")))?;
+
+        if !matched {
+            return Err(Error::Storage(
+                "localStorage probe check failed: written and read values do not match!".to_string(),
+            ));
+        }
+
+        Ok(Self { _ignored: () })
+    }
+
+    /// Use reflection instead of the `window` object to get hold of a reference to the local storage API.
+    /// This makes sure we can utilize it when running in nodejs with a mocked global
+    /// `window.localStorage` object.
+    fn storage() -> crate::wallet::Result<web_sys::Storage> {
+        let window_obj = js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("window"))
+            .map_err(|e| Error::Storage(format!("no window object found: {e:?}")))?;
+
+        let local_storage_obj = js_sys::Reflect::get(&window_obj, &JsValue::from_str("localStorage"))
+            .map_err(|e| Error::Storage(format!("no window.localStorage object found: {e:?}")))?;
+
+        let storage = web_sys::Storage::try_from(local_storage_obj)
+            .map_err(|e| Error::Storage(format!("window.localStorage should be web_sys::Storage: {e}")))?;
+        Ok(storage)
     }
 }
 
 #[async_trait::async_trait]
 impl StorageAdapter for WasmAdapter {
+    type Error = crate::wallet::Error;
+
     /// Gets the record associated with the given key from the storage.
-    async fn get(&self, key: &str) -> crate::wallet::Result<String> {
-        self.0.get(key)
+    async fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(Self::storage()?
+            .get_item(key)
+            .map_err(|e| Error::Storage(format!("get_item error: {e:?}")))?
+            .map(|s| s.into_bytes()))
     }
 
     /// Saves or updates a record on the storage.
-    async fn set(&mut self, key: &str, record: String) -> crate::wallet::Result<()> {
-        self.0.set(key, record)
-    }
+    async fn set_bytes(&self, key: &str, record: &[u8]) -> Result<(), Self::Error> {
+        // We always store valid UTF8 JSON, so this does not loose any information
+        let record = String::from_utf8_lossy(record);
 
-    /// Batch writes records to the storage.
-    async fn batch_set(&mut self, records: HashMap<String, String>) -> crate::wallet::Result<()> {
-        records.into_iter().map(|s| self.set(s.0, s.1));
-        Ok(())
+        Self::storage()?
+            .set_item(key, &record)
+            .map_err(|e| Error::Storage(format!("set_item error: {e:?}")))
     }
 
     /// Removes a record from the storage.
-    async fn remove(&mut self, key: &str) -> crate::wallet::Result<()> {
-        self.0.delete(key)
+    async fn delete(&self, key: &str) -> crate::wallet::Result<()> {
+        Self::storage()?
+            .delete(key)
+            .map_err(|e| Error::Storage(format!("delete error: {e:?}")))
     }
 }

--- a/sdk/src/wallet/storage/adapter/wasm.rs
+++ b/sdk/src/wallet/storage/adapter/wasm.rs
@@ -31,6 +31,7 @@ impl WasmAdapter {
         let out = || -> Result<bool, JsValue> {
             storage.set_item(PROBE_KEY, PROBE_VALUE)?;
             let read = storage.get_item(PROBE_KEY)?;
+            let _ = storage.remove_item(PROBE_KEY);
             Ok(read.is_some_and(|v| v == PROBE_VALUE))
         }();
 


### PR DESCRIPTION
# Description of change

This enables the `StorageAdapter` for `wasm`, and also makes sure it works in `nodejs` whenever the `window.localStorage` global exists 🚀 

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
