### PR TITLE
use path to create storage key prefix for multi-user support

### DIFF
--- a/sdk/src/wallet/core/builder.rs
+++ b/sdk/src/wallet/core/builder.rs
@@ -141,7 +141,7 @@ where
                     crate::wallet::storage::adapter::jammdb::JammdbStorageAdapter::new(storage_options.path.clone())?
                 } else if #[cfg(target_family = "wasm")] {
                     // if we are on wasm, try to use the browser local storage
-                    crate::wallet::storage::adapter::wasm::WasmAdapter::new()?
+                    crate::wallet::storage::adapter::wasm::WasmAdapter::new(storage_options.path.clone())?
                 } else {
                     crate::wallet::storage::adapter::memory::Memory::default()
                 }


### PR DESCRIPTION
# Description of change

Builds on #1 to use the `storage_path` setting to generate a prefix for the keys used when accessing the browser local storage. This correctly allows multiple wallets to be used just like when using the `jammdb` or `rocksdb` backends, while remaining compatible with the localStorage api that uses global key-value storage.

## Links to any relevant issues

Be sure to reference any related issues by adding `fixes #issue_number`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Tick the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that new and existing unit tests pass locally with my changes
